### PR TITLE
Make more room for TOC, give it its own scroll

### DIFF
--- a/supplemental_ui/partials/head-meta.hbs
+++ b/supplemental_ui/partials/head-meta.hbs
@@ -531,6 +531,7 @@ button {
 
   .nav {
     top: 68px;
+    height: 100%;
   }
 }
 

--- a/supplemental_ui/partials/head-meta.hbs
+++ b/supplemental_ui/partials/head-meta.hbs
@@ -529,17 +529,11 @@ button {
     color: #000;
   }
 
-  .nav {
-    top: 68px;
-    height: 100%;
-  }
 }
 
 
-@media screen and (min-width: 769px) {
-  .nav {
-    top: 38px;
-  }
+.nav-panel-menu {
+  height: auto;
 }
 
 article.doc {
@@ -727,10 +721,6 @@ aside.toc.sidebar {
 
 .panels {
   padding-left: 16px;
-}
-
-body ::-webkit-scrollbar-thumb {
-  background-color: initial;
 }
 
 .is-current-page>.nav-link,


### PR DESCRIPTION
This PR brings a separate scrollbar to the left-hand side TOC:

![image](https://user-images.githubusercontent.com/6579240/197240386-7f72cd58-8157-448d-ba5b-3d7fba838993.png)


