### PR TITLE
Revert vantage instance reference on ML quickstart due to mention of local installs.

### DIFF
--- a/modules/ROOT/pages/ml.adoc
+++ b/modules/ROOT/pages/ml.adoc
@@ -14,7 +14,7 @@ There are situations when you want to quickly validate a machine learning model 
 
 You need access to a Teradata Vantage instance.
 
-include::ROOT:partial$vantage_clearscape_analytics.adoc[]
+include::ROOT:partial$vantage.express.options.adoc.adoc[]
 
 == Install Vantage Analytics Library
 


### PR DESCRIPTION
Reverted vantage instance reference on ML-quickstarts to VM due to reference to direct installation of packages