### PR TITLE
Fix/old links

### DIFF
--- a/generate-redirects.js
+++ b/generate-redirects.js
@@ -90,7 +90,7 @@ const data = {
     "/quickstarts/vantagecloud-lake/vantagecloud-lake-demo-jupyter-google-cloud-vertex-ai/",
   "vantagecloud-lake/vantagecloud-lake-demo-jupyter-azure.html":
     "/quickstarts/vantagecloud-lake/vantagecloud-lake-demo-jupyter-azure/",
-    "vantagecloud-lake/vantagecloud-lake-compute-cluster-airflow.html":"quickstarts/vantagecloud-lake/vantagecloud-lake-compute-cluster-airflow/",
+    "vantagecloud-lake/vantagecloud-lake-compute-cluster-airflow.html":"/quickstarts/vantagecloud-lake/vantagecloud-lake-compute-cluster-airflow/",
     "airflow/airflow.html": "/quickstarts/manage-data/airflow/",
   // AI Unlimited redirects
   "ai-unlimited/ai-unlimited-aws-permissions-policies.html": "/ai-unlimited/install-ai-unlimited/",
@@ -102,6 +102,19 @@ const data = {
   "ai-unlimited/install-ai-unlimited-workspaces-docker.html": "/ai-unlimited/resources/quickstart/run-ai-unlimited-jupyterlab-docker/",
   "ai-unlimited/running-sample-ai-unlimited-workload.html": "/ai-unlimited/install-ai-unlimited/", 
   "ai-unlimited/using-ai-unlimited-workspace-cli.html": "/ai-unlimited/install-ai-unlimited/",
+  
+  "mule-teradata-connector/release-notes.html" : "/quickstarts/create-applications/mule-teradata-connector-release-notes/",
+  "fastload.html": "/quickstarts/",
+  "jupyter-demos/index.html": "/quickstarts/",
+  "mule-teradata-connector/examples-configuration.html": "/quickstarts/create-applications/examples-configuration/",
+  "mule-teradata-connector/index.html": "/quickstarts/create-applications/teradata-connector-mule4/",
+  "explain-plan.html": "/quickstarts/",
+  "regulus/install-regulus-docker-image.html": "/quickstarts/",
+  "geojson-to-vantage.html": "/quickstarts/analyze-data/geojson-to-vantage/",
+  "jupyter-demos/gcp-vertex-ai-pipelines-vantage-byom-housing-example.html":  "/quickstarts/",
+  "cloud-guides/ingest-catalog-data-teradata-s3-with-glue.html":"/quickstarts/manage-data/ingest-catalog-data-teradata-s3-with-glue/",
+  "/other/getting.started.intro.html": "/quickstarts/",
+  "mule-teradata-connector/reference.html": "/quickstarts/create-applications/examples-configuration/",
 };
 
 // Template generator function

--- a/generate-redirects.js
+++ b/generate-redirects.js
@@ -104,16 +104,16 @@ const data = {
   "ai-unlimited/using-ai-unlimited-workspace-cli.html": "/ai-unlimited/install-ai-unlimited/",
   
   "mule-teradata-connector/release-notes.html" : "/quickstarts/create-applications/mule-teradata-connector-release-notes/",
-  "fastload.html": "/quickstarts/",
-  "jupyter-demos/index.html": "/quickstarts/",
+  "fastload.html": "/",
+  "jupyter-demos/index.html": "/",
   "mule-teradata-connector/examples-configuration.html": "/quickstarts/create-applications/examples-configuration/",
   "mule-teradata-connector/index.html": "/quickstarts/create-applications/teradata-connector-mule4/",
-  "explain-plan.html": "/quickstarts/",
-  "regulus/install-regulus-docker-image.html": "/quickstarts/",
+  "explain-plan.html": "/",
+  "regulus/install-regulus-docker-image.html": "/",
   "geojson-to-vantage.html": "/quickstarts/analyze-data/geojson-to-vantage/",
-  "jupyter-demos/gcp-vertex-ai-pipelines-vantage-byom-housing-example.html":  "/quickstarts/",
+  "jupyter-demos/gcp-vertex-ai-pipelines-vantage-byom-housing-example.html":  "/",
   "cloud-guides/ingest-catalog-data-teradata-s3-with-glue.html":"/quickstarts/manage-data/ingest-catalog-data-teradata-s3-with-glue/",
-  "/other/getting.started.intro.html": "/quickstarts/",
+  "/other/getting.started.intro.html": "/",
   "mule-teradata-connector/reference.html": "/quickstarts/create-applications/examples-configuration/",
 };
 

--- a/generate-redirects.js
+++ b/generate-redirects.js
@@ -104,7 +104,7 @@ const data = {
   "ai-unlimited/using-ai-unlimited-workspace-cli.html": "/ai-unlimited/install-ai-unlimited/",
   
   "mule-teradata-connector/release-notes.html" : "/quickstarts/create-applications/mule-teradata-connector-release-notes/",
-  "fastload.html": "/",
+  "fastload.html": "/quickstarts/manage-data/fastload/",
   "jupyter-demos/index.html": "/",
   "mule-teradata-connector/examples-configuration.html": "/quickstarts/create-applications/examples-configuration/",
   "mule-teradata-connector/index.html": "/quickstarts/create-applications/teradata-connector-mule4/",

--- a/static/cloud-guides/ingest-catalog-data-teradata-s3-with-glue.html
+++ b/static/cloud-guides/ingest-catalog-data-teradata-s3-with-glue.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/quickstarts/manage-data/ingest-catalog-data-teradata-s3-with-glue/">
+<script>location="https://developers.teradata.com/quickstarts/manage-data/ingest-catalog-data-teradata-s3-with-glue/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/quickstarts/manage-data/ingest-catalog-data-teradata-s3-with-glue/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/quickstarts/manage-data/ingest-catalog-data-teradata-s3-with-glue/">https://developers.teradata.com/quickstarts/manage-data/ingest-catalog-data-teradata-s3-with-glue/</a>.</p>

--- a/static/es/cloud-guides/ingest-catalog-data-teradata-s3-with-glue.html
+++ b/static/es/cloud-guides/ingest-catalog-data-teradata-s3-with-glue.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/es/quickstarts/manage-data/ingest-catalog-data-teradata-s3-with-glue/">
+<script>location="https://developers.teradata.com/es/quickstarts/manage-data/ingest-catalog-data-teradata-s3-with-glue/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/quickstarts/manage-data/ingest-catalog-data-teradata-s3-with-glue/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/quickstarts/manage-data/ingest-catalog-data-teradata-s3-with-glue/">https://developers.teradata.com/es/quickstarts/manage-data/ingest-catalog-data-teradata-s3-with-glue/</a>.</p>

--- a/static/es/explain-plan.html
+++ b/static/es/explain-plan.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<link rel="canonical" href="https://developers.teradata.com/es/quickstarts/">
-<script>location="https://developers.teradata.com/es/quickstarts/"</script>
-<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/quickstarts/">
+<link rel="canonical" href="https://developers.teradata.com/es/">
+<script>location="https://developers.teradata.com/es/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/">
 <meta name="robots" content="noindex">
 <title>Redirect Notice</title>
 <h1>Redirect Notice</h1>
-<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/quickstarts/">https://developers.teradata.com/es/quickstarts/</a>.</p>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/">https://developers.teradata.com/es/</a>.</p>

--- a/static/es/explain-plan.html
+++ b/static/es/explain-plan.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/es/quickstarts/">
+<script>location="https://developers.teradata.com/es/quickstarts/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/quickstarts/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/quickstarts/">https://developers.teradata.com/es/quickstarts/</a>.</p>

--- a/static/es/fastload.html
+++ b/static/es/fastload.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<link rel="canonical" href="https://developers.teradata.com/es/quickstarts/">
-<script>location="https://developers.teradata.com/es/quickstarts/"</script>
-<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/quickstarts/">
+<link rel="canonical" href="https://developers.teradata.com/es/">
+<script>location="https://developers.teradata.com/es/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/">
 <meta name="robots" content="noindex">
 <title>Redirect Notice</title>
 <h1>Redirect Notice</h1>
-<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/quickstarts/">https://developers.teradata.com/es/quickstarts/</a>.</p>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/">https://developers.teradata.com/es/</a>.</p>

--- a/static/es/fastload.html
+++ b/static/es/fastload.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<link rel="canonical" href="https://developers.teradata.com/es/">
-<script>location="https://developers.teradata.com/es/"</script>
-<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/">
+<link rel="canonical" href="https://developers.teradata.com/es/quickstarts/manage-data/fastload/">
+<script>location="https://developers.teradata.com/es/quickstarts/manage-data/fastload/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/quickstarts/manage-data/fastload/">
 <meta name="robots" content="noindex">
 <title>Redirect Notice</title>
 <h1>Redirect Notice</h1>
-<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/">https://developers.teradata.com/es/</a>.</p>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/quickstarts/manage-data/fastload/">https://developers.teradata.com/es/quickstarts/manage-data/fastload/</a>.</p>

--- a/static/es/fastload.html
+++ b/static/es/fastload.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/es/quickstarts/">
+<script>location="https://developers.teradata.com/es/quickstarts/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/quickstarts/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/quickstarts/">https://developers.teradata.com/es/quickstarts/</a>.</p>

--- a/static/es/geojson-to-vantage.html
+++ b/static/es/geojson-to-vantage.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/es/quickstarts/analyze-data/geojson-to-vantage/">
+<script>location="https://developers.teradata.com/es/quickstarts/analyze-data/geojson-to-vantage/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/quickstarts/analyze-data/geojson-to-vantage/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/quickstarts/analyze-data/geojson-to-vantage/">https://developers.teradata.com/es/quickstarts/analyze-data/geojson-to-vantage/</a>.</p>

--- a/static/es/jupyter-demos/gcp-vertex-ai-pipelines-vantage-byom-housing-example.html
+++ b/static/es/jupyter-demos/gcp-vertex-ai-pipelines-vantage-byom-housing-example.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<link rel="canonical" href="https://developers.teradata.com/es/quickstarts/">
-<script>location="https://developers.teradata.com/es/quickstarts/"</script>
-<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/quickstarts/">
+<link rel="canonical" href="https://developers.teradata.com/es/">
+<script>location="https://developers.teradata.com/es/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/">
 <meta name="robots" content="noindex">
 <title>Redirect Notice</title>
 <h1>Redirect Notice</h1>
-<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/quickstarts/">https://developers.teradata.com/es/quickstarts/</a>.</p>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/">https://developers.teradata.com/es/</a>.</p>

--- a/static/es/jupyter-demos/gcp-vertex-ai-pipelines-vantage-byom-housing-example.html
+++ b/static/es/jupyter-demos/gcp-vertex-ai-pipelines-vantage-byom-housing-example.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/es/quickstarts/">
+<script>location="https://developers.teradata.com/es/quickstarts/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/quickstarts/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/quickstarts/">https://developers.teradata.com/es/quickstarts/</a>.</p>

--- a/static/es/jupyter-demos/index.html
+++ b/static/es/jupyter-demos/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<link rel="canonical" href="https://developers.teradata.com/es/quickstarts/">
-<script>location="https://developers.teradata.com/es/quickstarts/"</script>
-<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/quickstarts/">
+<link rel="canonical" href="https://developers.teradata.com/es/">
+<script>location="https://developers.teradata.com/es/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/">
 <meta name="robots" content="noindex">
 <title>Redirect Notice</title>
 <h1>Redirect Notice</h1>
-<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/quickstarts/">https://developers.teradata.com/es/quickstarts/</a>.</p>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/">https://developers.teradata.com/es/</a>.</p>

--- a/static/es/jupyter-demos/index.html
+++ b/static/es/jupyter-demos/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/es/quickstarts/">
+<script>location="https://developers.teradata.com/es/quickstarts/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/quickstarts/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/quickstarts/">https://developers.teradata.com/es/quickstarts/</a>.</p>

--- a/static/es/jupyter.html
+++ b/static/es/jupyter.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/es/quickstarts/analyze-data/jupyter/">
+<script>location="https://developers.teradata.com/es/quickstarts/analyze-data/jupyter/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/quickstarts/analyze-data/jupyter/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/quickstarts/analyze-data/jupyter/">https://developers.teradata.com/es/quickstarts/analyze-data/jupyter/</a>.</p>

--- a/static/es/mule-teradata-connector/examples-configuration.html
+++ b/static/es/mule-teradata-connector/examples-configuration.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/es/quickstarts/create-applications/examples-configuration/">
+<script>location="https://developers.teradata.com/es/quickstarts/create-applications/examples-configuration/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/quickstarts/create-applications/examples-configuration/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/quickstarts/create-applications/examples-configuration/">https://developers.teradata.com/es/quickstarts/create-applications/examples-configuration/</a>.</p>

--- a/static/es/mule-teradata-connector/index.html
+++ b/static/es/mule-teradata-connector/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/es/quickstarts/create-applications/teradata-connector-mule4/">
+<script>location="https://developers.teradata.com/es/quickstarts/create-applications/teradata-connector-mule4/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/quickstarts/create-applications/teradata-connector-mule4/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/quickstarts/create-applications/teradata-connector-mule4/">https://developers.teradata.com/es/quickstarts/create-applications/teradata-connector-mule4/</a>.</p>

--- a/static/es/mule-teradata-connector/reference.html
+++ b/static/es/mule-teradata-connector/reference.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/es/quickstarts/create-applications/examples-configuration/">
+<script>location="https://developers.teradata.com/es/quickstarts/create-applications/examples-configuration/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/quickstarts/create-applications/examples-configuration/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/quickstarts/create-applications/examples-configuration/">https://developers.teradata.com/es/quickstarts/create-applications/examples-configuration/</a>.</p>

--- a/static/es/mule-teradata-connector/release-notes.html
+++ b/static/es/mule-teradata-connector/release-notes.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/es/quickstarts/create-applications/mule-teradata-connector-release-notes/">
+<script>location="https://developers.teradata.com/es/quickstarts/create-applications/mule-teradata-connector-release-notes/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/quickstarts/create-applications/mule-teradata-connector-release-notes/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/quickstarts/create-applications/mule-teradata-connector-release-notes/">https://developers.teradata.com/es/quickstarts/create-applications/mule-teradata-connector-release-notes/</a>.</p>

--- a/static/es/other/getting.started.intro.html
+++ b/static/es/other/getting.started.intro.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<link rel="canonical" href="https://developers.teradata.com/es/quickstarts/">
-<script>location="https://developers.teradata.com/es/quickstarts/"</script>
-<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/quickstarts/">
+<link rel="canonical" href="https://developers.teradata.com/es/">
+<script>location="https://developers.teradata.com/es/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/">
 <meta name="robots" content="noindex">
 <title>Redirect Notice</title>
 <h1>Redirect Notice</h1>
-<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/quickstarts/">https://developers.teradata.com/es/quickstarts/</a>.</p>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/">https://developers.teradata.com/es/</a>.</p>

--- a/static/es/other/getting.started.intro.html
+++ b/static/es/other/getting.started.intro.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/es/quickstarts/">
+<script>location="https://developers.teradata.com/es/quickstarts/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/quickstarts/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/quickstarts/">https://developers.teradata.com/es/quickstarts/</a>.</p>

--- a/static/es/regulus/install-regulus-docker-image.html
+++ b/static/es/regulus/install-regulus-docker-image.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<link rel="canonical" href="https://developers.teradata.com/es/quickstarts/">
-<script>location="https://developers.teradata.com/es/quickstarts/"</script>
-<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/quickstarts/">
+<link rel="canonical" href="https://developers.teradata.com/es/">
+<script>location="https://developers.teradata.com/es/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/">
 <meta name="robots" content="noindex">
 <title>Redirect Notice</title>
 <h1>Redirect Notice</h1>
-<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/quickstarts/">https://developers.teradata.com/es/quickstarts/</a>.</p>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/">https://developers.teradata.com/es/</a>.</p>

--- a/static/es/regulus/install-regulus-docker-image.html
+++ b/static/es/regulus/install-regulus-docker-image.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/es/quickstarts/">
+<script>location="https://developers.teradata.com/es/quickstarts/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/es/quickstarts/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/es/quickstarts/">https://developers.teradata.com/es/quickstarts/</a>.</p>

--- a/static/explain-plan.html
+++ b/static/explain-plan.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/quickstarts/">
+<script>location="https://developers.teradata.com/quickstarts/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/quickstarts/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/quickstarts/">https://developers.teradata.com/quickstarts/</a>.</p>

--- a/static/explain-plan.html
+++ b/static/explain-plan.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<link rel="canonical" href="https://developers.teradata.com/quickstarts/">
-<script>location="https://developers.teradata.com/quickstarts/"</script>
-<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/quickstarts/">
+<link rel="canonical" href="https://developers.teradata.com/">
+<script>location="https://developers.teradata.com/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/">
 <meta name="robots" content="noindex">
 <title>Redirect Notice</title>
 <h1>Redirect Notice</h1>
-<p>The page you requested has been relocated to <a href="https://developers.teradata.com/quickstarts/">https://developers.teradata.com/quickstarts/</a>.</p>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/">https://developers.teradata.com/</a>.</p>

--- a/static/fastload.html
+++ b/static/fastload.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/quickstarts/">
+<script>location="https://developers.teradata.com/quickstarts/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/quickstarts/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/quickstarts/">https://developers.teradata.com/quickstarts/</a>.</p>

--- a/static/fastload.html
+++ b/static/fastload.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<link rel="canonical" href="https://developers.teradata.com/">
-<script>location="https://developers.teradata.com/"</script>
-<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/">
+<link rel="canonical" href="https://developers.teradata.com/quickstarts/manage-data/fastload/">
+<script>location="https://developers.teradata.com/quickstarts/manage-data/fastload/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/quickstarts/manage-data/fastload/">
 <meta name="robots" content="noindex">
 <title>Redirect Notice</title>
 <h1>Redirect Notice</h1>
-<p>The page you requested has been relocated to <a href="https://developers.teradata.com/">https://developers.teradata.com/</a>.</p>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/quickstarts/manage-data/fastload/">https://developers.teradata.com/quickstarts/manage-data/fastload/</a>.</p>

--- a/static/fastload.html
+++ b/static/fastload.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<link rel="canonical" href="https://developers.teradata.com/quickstarts/">
-<script>location="https://developers.teradata.com/quickstarts/"</script>
-<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/quickstarts/">
+<link rel="canonical" href="https://developers.teradata.com/">
+<script>location="https://developers.teradata.com/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/">
 <meta name="robots" content="noindex">
 <title>Redirect Notice</title>
 <h1>Redirect Notice</h1>
-<p>The page you requested has been relocated to <a href="https://developers.teradata.com/quickstarts/">https://developers.teradata.com/quickstarts/</a>.</p>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/">https://developers.teradata.com/</a>.</p>

--- a/static/geojson-to-vantage.html
+++ b/static/geojson-to-vantage.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/quickstarts/analyze-data/geojson-to-vantage/">
+<script>location="https://developers.teradata.com/quickstarts/analyze-data/geojson-to-vantage/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/quickstarts/analyze-data/geojson-to-vantage/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/quickstarts/analyze-data/geojson-to-vantage/">https://developers.teradata.com/quickstarts/analyze-data/geojson-to-vantage/</a>.</p>

--- a/static/ja/cloud-guides/ingest-catalog-data-teradata-s3-with-glue.html
+++ b/static/ja/cloud-guides/ingest-catalog-data-teradata-s3-with-glue.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/ja/quickstarts/manage-data/ingest-catalog-data-teradata-s3-with-glue/">
+<script>location="https://developers.teradata.com/ja/quickstarts/manage-data/ingest-catalog-data-teradata-s3-with-glue/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/quickstarts/manage-data/ingest-catalog-data-teradata-s3-with-glue/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/quickstarts/manage-data/ingest-catalog-data-teradata-s3-with-glue/">https://developers.teradata.com/ja/quickstarts/manage-data/ingest-catalog-data-teradata-s3-with-glue/</a>.</p>

--- a/static/ja/explain-plan.html
+++ b/static/ja/explain-plan.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/ja/quickstarts/">
+<script>location="https://developers.teradata.com/ja/quickstarts/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/quickstarts/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/quickstarts/">https://developers.teradata.com/ja/quickstarts/</a>.</p>

--- a/static/ja/explain-plan.html
+++ b/static/ja/explain-plan.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<link rel="canonical" href="https://developers.teradata.com/ja/quickstarts/">
-<script>location="https://developers.teradata.com/ja/quickstarts/"</script>
-<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/quickstarts/">
+<link rel="canonical" href="https://developers.teradata.com/ja/">
+<script>location="https://developers.teradata.com/ja/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/">
 <meta name="robots" content="noindex">
 <title>Redirect Notice</title>
 <h1>Redirect Notice</h1>
-<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/quickstarts/">https://developers.teradata.com/ja/quickstarts/</a>.</p>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/">https://developers.teradata.com/ja/</a>.</p>

--- a/static/ja/fastload.html
+++ b/static/ja/fastload.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<link rel="canonical" href="https://developers.teradata.com/ja/">
-<script>location="https://developers.teradata.com/ja/"</script>
-<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/">
+<link rel="canonical" href="https://developers.teradata.com/ja/quickstarts/manage-data/fastload/">
+<script>location="https://developers.teradata.com/ja/quickstarts/manage-data/fastload/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/quickstarts/manage-data/fastload/">
 <meta name="robots" content="noindex">
 <title>Redirect Notice</title>
 <h1>Redirect Notice</h1>
-<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/">https://developers.teradata.com/ja/</a>.</p>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/quickstarts/manage-data/fastload/">https://developers.teradata.com/ja/quickstarts/manage-data/fastload/</a>.</p>

--- a/static/ja/fastload.html
+++ b/static/ja/fastload.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/ja/quickstarts/">
+<script>location="https://developers.teradata.com/ja/quickstarts/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/quickstarts/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/quickstarts/">https://developers.teradata.com/ja/quickstarts/</a>.</p>

--- a/static/ja/fastload.html
+++ b/static/ja/fastload.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<link rel="canonical" href="https://developers.teradata.com/ja/quickstarts/">
-<script>location="https://developers.teradata.com/ja/quickstarts/"</script>
-<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/quickstarts/">
+<link rel="canonical" href="https://developers.teradata.com/ja/">
+<script>location="https://developers.teradata.com/ja/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/">
 <meta name="robots" content="noindex">
 <title>Redirect Notice</title>
 <h1>Redirect Notice</h1>
-<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/quickstarts/">https://developers.teradata.com/ja/quickstarts/</a>.</p>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/">https://developers.teradata.com/ja/</a>.</p>

--- a/static/ja/geojson-to-vantage.html
+++ b/static/ja/geojson-to-vantage.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/ja/quickstarts/analyze-data/geojson-to-vantage/">
+<script>location="https://developers.teradata.com/ja/quickstarts/analyze-data/geojson-to-vantage/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/quickstarts/analyze-data/geojson-to-vantage/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/quickstarts/analyze-data/geojson-to-vantage/">https://developers.teradata.com/ja/quickstarts/analyze-data/geojson-to-vantage/</a>.</p>

--- a/static/ja/jupyter-demos/gcp-vertex-ai-pipelines-vantage-byom-housing-example.html
+++ b/static/ja/jupyter-demos/gcp-vertex-ai-pipelines-vantage-byom-housing-example.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/ja/quickstarts/">
+<script>location="https://developers.teradata.com/ja/quickstarts/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/quickstarts/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/quickstarts/">https://developers.teradata.com/ja/quickstarts/</a>.</p>

--- a/static/ja/jupyter-demos/gcp-vertex-ai-pipelines-vantage-byom-housing-example.html
+++ b/static/ja/jupyter-demos/gcp-vertex-ai-pipelines-vantage-byom-housing-example.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<link rel="canonical" href="https://developers.teradata.com/ja/quickstarts/">
-<script>location="https://developers.teradata.com/ja/quickstarts/"</script>
-<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/quickstarts/">
+<link rel="canonical" href="https://developers.teradata.com/ja/">
+<script>location="https://developers.teradata.com/ja/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/">
 <meta name="robots" content="noindex">
 <title>Redirect Notice</title>
 <h1>Redirect Notice</h1>
-<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/quickstarts/">https://developers.teradata.com/ja/quickstarts/</a>.</p>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/">https://developers.teradata.com/ja/</a>.</p>

--- a/static/ja/jupyter-demos/index.html
+++ b/static/ja/jupyter-demos/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/ja/quickstarts/">
+<script>location="https://developers.teradata.com/ja/quickstarts/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/quickstarts/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/quickstarts/">https://developers.teradata.com/ja/quickstarts/</a>.</p>

--- a/static/ja/jupyter-demos/index.html
+++ b/static/ja/jupyter-demos/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<link rel="canonical" href="https://developers.teradata.com/ja/quickstarts/">
-<script>location="https://developers.teradata.com/ja/quickstarts/"</script>
-<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/quickstarts/">
+<link rel="canonical" href="https://developers.teradata.com/ja/">
+<script>location="https://developers.teradata.com/ja/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/">
 <meta name="robots" content="noindex">
 <title>Redirect Notice</title>
 <h1>Redirect Notice</h1>
-<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/quickstarts/">https://developers.teradata.com/ja/quickstarts/</a>.</p>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/">https://developers.teradata.com/ja/</a>.</p>

--- a/static/ja/jupyter.html
+++ b/static/ja/jupyter.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/ja/quickstarts/analyze-data/jupyter/">
+<script>location="https://developers.teradata.com/ja/quickstarts/analyze-data/jupyter/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/quickstarts/analyze-data/jupyter/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/quickstarts/analyze-data/jupyter/">https://developers.teradata.com/ja/quickstarts/analyze-data/jupyter/</a>.</p>

--- a/static/ja/mule-teradata-connector/examples-configuration.html
+++ b/static/ja/mule-teradata-connector/examples-configuration.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/ja/quickstarts/create-applications/examples-configuration/">
+<script>location="https://developers.teradata.com/ja/quickstarts/create-applications/examples-configuration/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/quickstarts/create-applications/examples-configuration/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/quickstarts/create-applications/examples-configuration/">https://developers.teradata.com/ja/quickstarts/create-applications/examples-configuration/</a>.</p>

--- a/static/ja/mule-teradata-connector/index.html
+++ b/static/ja/mule-teradata-connector/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/ja/quickstarts/create-applications/teradata-connector-mule4/">
+<script>location="https://developers.teradata.com/ja/quickstarts/create-applications/teradata-connector-mule4/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/quickstarts/create-applications/teradata-connector-mule4/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/quickstarts/create-applications/teradata-connector-mule4/">https://developers.teradata.com/ja/quickstarts/create-applications/teradata-connector-mule4/</a>.</p>

--- a/static/ja/mule-teradata-connector/reference.html
+++ b/static/ja/mule-teradata-connector/reference.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/ja/quickstarts/create-applications/examples-configuration/">
+<script>location="https://developers.teradata.com/ja/quickstarts/create-applications/examples-configuration/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/quickstarts/create-applications/examples-configuration/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/quickstarts/create-applications/examples-configuration/">https://developers.teradata.com/ja/quickstarts/create-applications/examples-configuration/</a>.</p>

--- a/static/ja/mule-teradata-connector/release-notes.html
+++ b/static/ja/mule-teradata-connector/release-notes.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/ja/quickstarts/create-applications/mule-teradata-connector-release-notes/">
+<script>location="https://developers.teradata.com/ja/quickstarts/create-applications/mule-teradata-connector-release-notes/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/quickstarts/create-applications/mule-teradata-connector-release-notes/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/quickstarts/create-applications/mule-teradata-connector-release-notes/">https://developers.teradata.com/ja/quickstarts/create-applications/mule-teradata-connector-release-notes/</a>.</p>

--- a/static/ja/other/getting.started.intro.html
+++ b/static/ja/other/getting.started.intro.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/ja/quickstarts/">
+<script>location="https://developers.teradata.com/ja/quickstarts/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/quickstarts/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/quickstarts/">https://developers.teradata.com/ja/quickstarts/</a>.</p>

--- a/static/ja/other/getting.started.intro.html
+++ b/static/ja/other/getting.started.intro.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<link rel="canonical" href="https://developers.teradata.com/ja/quickstarts/">
-<script>location="https://developers.teradata.com/ja/quickstarts/"</script>
-<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/quickstarts/">
+<link rel="canonical" href="https://developers.teradata.com/ja/">
+<script>location="https://developers.teradata.com/ja/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/">
 <meta name="robots" content="noindex">
 <title>Redirect Notice</title>
 <h1>Redirect Notice</h1>
-<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/quickstarts/">https://developers.teradata.com/ja/quickstarts/</a>.</p>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/">https://developers.teradata.com/ja/</a>.</p>

--- a/static/ja/regulus/install-regulus-docker-image.html
+++ b/static/ja/regulus/install-regulus-docker-image.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/ja/quickstarts/">
+<script>location="https://developers.teradata.com/ja/quickstarts/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/quickstarts/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/quickstarts/">https://developers.teradata.com/ja/quickstarts/</a>.</p>

--- a/static/ja/regulus/install-regulus-docker-image.html
+++ b/static/ja/regulus/install-regulus-docker-image.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<link rel="canonical" href="https://developers.teradata.com/ja/quickstarts/">
-<script>location="https://developers.teradata.com/ja/quickstarts/"</script>
-<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/quickstarts/">
+<link rel="canonical" href="https://developers.teradata.com/ja/">
+<script>location="https://developers.teradata.com/ja/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/ja/">
 <meta name="robots" content="noindex">
 <title>Redirect Notice</title>
 <h1>Redirect Notice</h1>
-<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/quickstarts/">https://developers.teradata.com/ja/quickstarts/</a>.</p>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/ja/">https://developers.teradata.com/ja/</a>.</p>

--- a/static/jupyter-demos/gcp-vertex-ai-pipelines-vantage-byom-housing-example.html
+++ b/static/jupyter-demos/gcp-vertex-ai-pipelines-vantage-byom-housing-example.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/quickstarts/">
+<script>location="https://developers.teradata.com/quickstarts/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/quickstarts/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/quickstarts/">https://developers.teradata.com/quickstarts/</a>.</p>

--- a/static/jupyter-demos/gcp-vertex-ai-pipelines-vantage-byom-housing-example.html
+++ b/static/jupyter-demos/gcp-vertex-ai-pipelines-vantage-byom-housing-example.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<link rel="canonical" href="https://developers.teradata.com/quickstarts/">
-<script>location="https://developers.teradata.com/quickstarts/"</script>
-<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/quickstarts/">
+<link rel="canonical" href="https://developers.teradata.com/">
+<script>location="https://developers.teradata.com/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/">
 <meta name="robots" content="noindex">
 <title>Redirect Notice</title>
 <h1>Redirect Notice</h1>
-<p>The page you requested has been relocated to <a href="https://developers.teradata.com/quickstarts/">https://developers.teradata.com/quickstarts/</a>.</p>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/">https://developers.teradata.com/</a>.</p>

--- a/static/jupyter-demos/index.html
+++ b/static/jupyter-demos/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/quickstarts/">
+<script>location="https://developers.teradata.com/quickstarts/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/quickstarts/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/quickstarts/">https://developers.teradata.com/quickstarts/</a>.</p>

--- a/static/jupyter-demos/index.html
+++ b/static/jupyter-demos/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<link rel="canonical" href="https://developers.teradata.com/quickstarts/">
-<script>location="https://developers.teradata.com/quickstarts/"</script>
-<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/quickstarts/">
+<link rel="canonical" href="https://developers.teradata.com/">
+<script>location="https://developers.teradata.com/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/">
 <meta name="robots" content="noindex">
 <title>Redirect Notice</title>
 <h1>Redirect Notice</h1>
-<p>The page you requested has been relocated to <a href="https://developers.teradata.com/quickstarts/">https://developers.teradata.com/quickstarts/</a>.</p>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/">https://developers.teradata.com/</a>.</p>

--- a/static/mule-teradata-connector/examples-configuration.html
+++ b/static/mule-teradata-connector/examples-configuration.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/quickstarts/create-applications/examples-configuration/">
+<script>location="https://developers.teradata.com/quickstarts/create-applications/examples-configuration/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/quickstarts/create-applications/examples-configuration/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/quickstarts/create-applications/examples-configuration/">https://developers.teradata.com/quickstarts/create-applications/examples-configuration/</a>.</p>

--- a/static/mule-teradata-connector/index.html
+++ b/static/mule-teradata-connector/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/quickstarts/create-applications/teradata-connector-mule4/">
+<script>location="https://developers.teradata.com/quickstarts/create-applications/teradata-connector-mule4/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/quickstarts/create-applications/teradata-connector-mule4/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/quickstarts/create-applications/teradata-connector-mule4/">https://developers.teradata.com/quickstarts/create-applications/teradata-connector-mule4/</a>.</p>

--- a/static/mule-teradata-connector/reference.html
+++ b/static/mule-teradata-connector/reference.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/quickstarts/create-applications/examples-configuration/">
+<script>location="https://developers.teradata.com/quickstarts/create-applications/examples-configuration/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/quickstarts/create-applications/examples-configuration/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/quickstarts/create-applications/examples-configuration/">https://developers.teradata.com/quickstarts/create-applications/examples-configuration/</a>.</p>

--- a/static/mule-teradata-connector/release-notes.html
+++ b/static/mule-teradata-connector/release-notes.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/quickstarts/create-applications/mule-teradata-connector-release-notes/">
+<script>location="https://developers.teradata.com/quickstarts/create-applications/mule-teradata-connector-release-notes/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/quickstarts/create-applications/mule-teradata-connector-release-notes/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/quickstarts/create-applications/mule-teradata-connector-release-notes/">https://developers.teradata.com/quickstarts/create-applications/mule-teradata-connector-release-notes/</a>.</p>

--- a/static/other/getting.started.intro.html
+++ b/static/other/getting.started.intro.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/quickstarts/">
+<script>location="https://developers.teradata.com/quickstarts/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/quickstarts/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/quickstarts/">https://developers.teradata.com/quickstarts/</a>.</p>

--- a/static/other/getting.started.intro.html
+++ b/static/other/getting.started.intro.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<link rel="canonical" href="https://developers.teradata.com/quickstarts/">
-<script>location="https://developers.teradata.com/quickstarts/"</script>
-<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/quickstarts/">
+<link rel="canonical" href="https://developers.teradata.com/">
+<script>location="https://developers.teradata.com/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/">
 <meta name="robots" content="noindex">
 <title>Redirect Notice</title>
 <h1>Redirect Notice</h1>
-<p>The page you requested has been relocated to <a href="https://developers.teradata.com/quickstarts/">https://developers.teradata.com/quickstarts/</a>.</p>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/">https://developers.teradata.com/</a>.</p>

--- a/static/regulus/install-regulus-docker-image.html
+++ b/static/regulus/install-regulus-docker-image.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="canonical" href="https://developers.teradata.com/quickstarts/">
+<script>location="https://developers.teradata.com/quickstarts/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/quickstarts/">
+<meta name="robots" content="noindex">
+<title>Redirect Notice</title>
+<h1>Redirect Notice</h1>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/quickstarts/">https://developers.teradata.com/quickstarts/</a>.</p>

--- a/static/regulus/install-regulus-docker-image.html
+++ b/static/regulus/install-regulus-docker-image.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<link rel="canonical" href="https://developers.teradata.com/quickstarts/">
-<script>location="https://developers.teradata.com/quickstarts/"</script>
-<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/quickstarts/">
+<link rel="canonical" href="https://developers.teradata.com/">
+<script>location="https://developers.teradata.com/"</script>
+<meta http-equiv="refresh" content="0; url=https://developers.teradata.com/">
 <meta name="robots" content="noindex">
 <title>Redirect Notice</title>
 <h1>Redirect Notice</h1>
-<p>The page you requested has been relocated to <a href="https://developers.teradata.com/quickstarts/">https://developers.teradata.com/quickstarts/</a>.</p>
+<p>The page you requested has been relocated to <a href="https://developers.teradata.com/">https://developers.teradata.com/</a>.</p>


### PR DESCRIPTION
Update missing old links to new quickstarts

"mule-teradata-connector/release-notes.html" : "/quickstarts/create-applications/mule-teradata-connector-release-notes/",
  "fastload.html": "/quickstarts/",
  "jupyter-demos/index.html": "/quickstarts/",
  "mule-teradata-connector/examples-configuration.html": "/quickstarts/create-applications/examples-configuration/",
  "mule-teradata-connector/index.html": "/quickstarts/create-applications/teradata-connector-mule4/",
  "explain-plan.html": "/quickstarts/",
  "regulus/install-regulus-docker-image.html": "/quickstarts/",
  "geojson-to-vantage.html": "/quickstarts/analyze-data/geojson-to-vantage/",
  "jupyter-demos/gcp-vertex-ai-pipelines-vantage-byom-housing-example.html":  "/quickstarts/",
  "cloud-guides/ingest-catalog-data-teradata-s3-with-glue.html":"/quickstarts/manage-data/ingest-catalog-data-teradata-s3-with-glue/",
  "/other/getting.started.intro.html": "/quickstarts/",
  "mule-teradata-connector/reference.html": "/quickstarts/create-applications/examples-configuration/",